### PR TITLE
fix mark operation failing with error

### DIFF
--- a/vhost/cgi-bin/config/phrasebook.ini
+++ b/vhost/cgi-bin/config/phrasebook.ini
@@ -254,7 +254,7 @@ MapAddresses=REPLACE ixaddress SET userid=?,addressid=?
 
 RegisteredEmails=SELECT * FROM ixtester WHERE userid=?
 FindTesterIndex=SELECT xt.*,ta.addressid FROM ixtester xt \
-    LEFT JOIN testers.address AS ta ON xa.email = xt.email \
+    LEFT JOIN testers.address AS ta ON ta.email = xt.email \
     WHERE xt.email=?
 RemoveEmail=DELETE FROM ixtester WHERE userid=? AND email IN ($mails)
 ConfirmedEmail=UPDATE ixtester SET confirmed=1,confirm='' WHERE userid=? AND email=? AND confirm=?


### PR DESCRIPTION
A typo in a select query prevented the marking of reports from happening.
